### PR TITLE
Improve Flow error processing

### DIFF
--- a/autoload/neomake/makers/ft/javascript.vim
+++ b/autoload/neomake/makers/ft/javascript.vim
@@ -45,7 +45,7 @@ function! neomake#makers#ft#javascript#flow()
     let mapexpr = 'substitute(v:val, "\\\\n", " ", "g")'
     return {
         \ 'args': ['check', '--one-line'],
-        \ 'errorformat': '%f:%l:%c\,%n: %m',
+        \ 'errorformat': '%f:%l %m',
         \ 'mapexpr': mapexpr,
         \ }
 endfunction


### PR DESCRIPTION
## Problem:

Neomake does not properly recognize Flow error messages,
and therefore fails to display alert icons in the file's gutter
next to the offending line number.

## Solution:

Modify Flow's `errorformat` so Neomake doesn't expect a character number,
which wasn't actually being displayed.

This fixes the alert icon in vim's gutter, but still results in a messy error message at the bottom of the screen.